### PR TITLE
Fix navigation layout

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,7 +34,16 @@
 <body>
   <div class="flex flex-col min-h-screen">
     <% if user_signed_in? %>
-      <%= render 'shared/header' %>
+    <!-- PC版ヘッダー -->
+    <div class="hidden lg:block">
+        <%= render 'shared/header' %>
+    </div>
+
+    <!-- スマホ版ヘッダー -->
+    <div class="flex lg:hidden">
+        <%= render 'shared/header_sp' %>
+    </div>
+  
     <% else %>
       <%= render 'shared/before_login_header' %>
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,12 +36,12 @@
     <% if user_signed_in? %>
     <!-- PC版ヘッダー -->
     <div class="hidden lg:block">
-        <%= render 'shared/header' %>
+      <%= render 'shared/header' %>
     </div>
 
     <!-- スマホ版ヘッダー -->
     <div class="flex lg:hidden">
-        <%= render 'shared/header_sp' %>
+      <%= render 'shared/header_sp' %>
     </div>
   
     <% else %>
@@ -52,7 +52,16 @@
       <%= yield %>
     </main>
 
-    <%= render 'shared/footer' %>
+    <!-- PC版フッター -->
+    <div class="hidden lg:block">
+      <%= render 'shared/footer' %>
+    </div>
+
+    <!-- スマホ版フッター -->
+    <div class="flex lg:hidden">
+      <%= render 'shared/footer_sp' %>
+    </div>
+
   </div>
 </body>
 </html>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,21 +1,7 @@
-<footer class="fixed bottom-0 left-0 w-full bg-gray-800 text-white z-50">
-  <nav class="flex justify-around items-center py-3 text-xs">
-    <!-- 行き先を決める -->
-    <%= link_to destinations_path, class: "flex flex-col items-center hover:opacity-80 transition" do %>
-      <i class="ri-map-pin-line text-2xl"></i>
-      <span>行き先</span>
-    <% end %>
-
-    <!-- みんなの投稿 -->
-    <%= link_to posts_path, class: "flex flex-col items-center hover:opacity-80 transition" do %>
-      <i class="ri-group-line text-2xl"></i>
-      <span>投稿一覧</span>
-    <% end %>
-
-    <!-- モンスター牧場 -->
-    <%= link_to user_monsters_path, class: "flex flex-col items-center hover:opacity-80 transition" do %>
-      <i class="ri-home-4-line text-2xl"></i>
-      <span>モンスター牧場</span>
-    <% end %>
-  </nav>
+<footer class="hidden lg:flex fixed bottom-0 left-0 w-full bg-gray-800 text-gray-200 items-center justify-center py-6 z-50">
+  <div class="flex justify-center w-full max-w-full px-4">
+    <p class="text-sm font-semibold text-center">
+      &copy; 2025 Walking Monster. All rights reserved.
+    </p>
+  </div>
 </footer>

--- a/app/views/shared/_footer_sp.html.erb
+++ b/app/views/shared/_footer_sp.html.erb
@@ -1,0 +1,28 @@
+<footer class="fixed bottom-0 left-0 w-full bg-gray-800 text-white z-50">
+  <nav class="flex justify-around items-center py-3 text-xs">
+
+    <!-- ホーム -->
+    <%= link_to root_path, class: "flex flex-col items-center hover:opacity-80 transition" do %>
+      <i class="ri-home-4-line text-2xl"></i>
+      <span>ホーム</span>
+    <% end %>
+
+    <!-- 行き先を決める -->
+    <%= link_to destinations_path, class: "flex flex-col items-center hover:opacity-80 transition" do %>
+      <i class="ri-map-pin-line text-2xl"></i>
+      <span>行き先</span>
+    <% end %>
+
+    <!-- みんなの投稿 -->
+    <%= link_to posts_path, class: "flex flex-col items-center hover:opacity-80 transition" do %>
+      <i class="ri-group-line text-2xl"></i>
+      <span>投稿一覧</span>
+    <% end %>
+
+    <!-- モンスター牧場 -->
+    <%= link_to user_monsters_path, class: "flex flex-col items-center hover:opacity-80 transition" do %>
+      <i class="ri-bear-smile-line text-2xl"></i>
+      <span>モンスター牧場</span>
+    <% end %>
+  </nav>
+</footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,19 +1,33 @@
-<header class="fixed top-0 left-0 w-full bg-orange-500 py-3 shadow-md z-50">
+<header class="fixed top-0 left-0 w-full bg-orange-500 py-3 shadow-md z-50"> 
   <div class="container mx-auto flex items-center px-4 relative">
+    
+    <!-- 左上サイドメニューボタン  -->
+    <div class="flex-shrink-0 hidden lg:block">
+      <button id="toggleSideMenu" 
+        class="w-10 h-10 bg-white rounded-full shadow-md flex items-center justify-center hover:bg-orange-300 transition">
+        <svg class="w-6 h-6 text-orange-500" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"/>
+        </svg>
+      </button>
+    </div>
+
     <!-- タイトル中央 -->
     <h1 class="text-white text-lg font-semibold absolute left-1/2 transform -translate-x-1/2">
       <%= link_to "Walking Monster", root_path, class: "hover:opacity-80" %>
     </h1>
 
-    <!-- ハンバーガーメニュー（右端） -->
+    <!-- 右端 ユーザーメニュー -->
     <div class="ml-auto relative">
-      <button id="hamburgerButton" class="p-2 w-10 h-10 rounded-full bg-white hover:bg-orange-300 transition shadow-md flex items-center justify-center">
-        <svg class="w-6 h-6 text-orange-500" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+      <button id="userMenuButton" 
+        class="p-2 w-10 h-10 rounded-full bg-white hover:bg-orange-300 transition shadow-md flex items-center justify-center">
+        <svg class="w-6 h-6 text-orange-500" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M12 12c2.7 0 4.8-2.1 4.8-4.8S14.7 2.4 12 2.4 7.2 4.5 7.2 7.2 9.3 12 12 12zm0 2.4c-3.2 0-9.6 1.6-9.6 4.8v1.2h19.2v-1.2c0-3.2-6.4-4.8-9.6-4.8z"/>
         </svg>
       </button>
 
-      <div id="hamburgerMenu" class="hidden absolute right-0 mt-2 w-60 bg-white rounded-xl shadow-xl ring-1 ring-gray-200 z-50 transition transform origin-top animate-fade-in-down">
+      <!-- ドロップダウンメニュー -->
+      <div id="userMenu" 
+        class="hidden absolute right-0 mt-2 w-60 bg-white rounded-xl shadow-xl ring-1 ring-gray-200 z-50 transition transform origin-top animate-fade-in-down">
         <%= link_to "プロフィール", user_profile_path, class: "block px-5 py-3 text-gray-700 hover:bg-gray-100 font-medium" %>
         <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { turbo_method: :delete }, class: "block px-5 py-3 text-gray-700 hover:bg-gray-100 font-medium" %>
         <%= link_to "お問い合わせ", contact_path, class: "block px-5 py-3 text-gray-700 hover:bg-gray-100 font-medium" %>
@@ -24,24 +38,60 @@
   </div>
 </header>
 
+<!-- サイドメニュー -->
+<nav id="sideMenu" 
+  class="fixed top-0 left-0 h-full w-64 
+         bg-gradient-to-b from-orange-600 via-gray-900 to-gray-900 
+         text-white shadow-2xl z-40 
+         transform -translate-x-full transition-transform duration-300 ease-in-out pt-20">
+
+  <%= link_to root_path, class: "flex items-center px-5 py-4 hover:bg-gray-800 hover:border-l-4 hover:border-orange-400 transition" do %>
+    <i class="ri-home-4-line text-2xl text-yellow-400"></i>
+    <span class="ml-3 font-medium">ホーム</span>
+  <% end %>
+
+  <%= link_to destinations_path, class: "flex items-center px-5 py-4 hover:bg-gray-800 hover:border-l-4 hover:border-orange-400 transition" do %>
+    <i class="ri-map-pin-line text-2xl text-yellow-400"></i>
+    <span class="ml-3 font-medium">行き先を決める</span>
+  <% end %>
+
+  <%= link_to posts_path, class: "flex items-center px-5 py-4 hover:bg-gray-800 hover:border-l-4 hover:border-orange-400 transition" do %>
+    <i class="ri-group-line text-2xl text-yellow-400"></i>
+    <span class="ml-3 font-medium">みんなの投稿</span>
+  <% end %>
+
+  <%= link_to user_monsters_path, class: "flex items-center px-5 py-4 hover:bg-gray-800 hover:border-l-4 hover:border-orange-400 transition" do %>
+    <i class="ri-bear-smile-line text-2xl text-yellow-400"></i>
+    <span class="ml-3 font-medium">モンスター牧場</span>
+  <% end %>
+</nav>
+
+<!-- JavaScript -->
 <script>
-  document.addEventListener("turbo:load", () => {
-    const button = document.getElementById("hamburgerButton");
-    const menu = document.getElementById("hamburgerMenu");
-
-    if (!button || !menu) return;
-
-    // ボタンクリックで開閉
-    button.addEventListener("click", (e) => {
+document.addEventListener("turbo:load", () => {
+  // ユーザーメニュー開閉
+  const userButton = document.getElementById("userMenuButton");
+  const userMenu = document.getElementById("userMenu");
+  if (userButton && userMenu) {
+    userButton.onclick = (e) => {
       e.stopPropagation();
-      menu.classList.toggle("hidden");
-    });
-
-    // メニュー外クリックで閉じる
+      userMenu.classList.toggle("hidden");
+    };
     document.addEventListener("click", (e) => {
-      if (!menu.contains(e.target) && !button.contains(e.target)) {
-        menu.classList.add("hidden");
+      if (!userMenu.contains(e.target) && !userButton.contains(e.target)) {
+        userMenu.classList.add("hidden");
       }
     });
-  });
+  }
+
+  // サイドメニュー開閉（トグル）
+  const toggleButton = document.getElementById("toggleSideMenu");
+  const sideMenu = document.getElementById("sideMenu");
+  if (toggleButton && sideMenu) {
+    toggleButton.onclick = () => {
+      sideMenu.classList.toggle("-translate-x-full");
+      sideMenu.classList.toggle("translate-x-0");
+    };
+  }
+});
 </script>

--- a/app/views/shared/_header_sp.html.erb
+++ b/app/views/shared/_header_sp.html.erb
@@ -1,0 +1,49 @@
+<header class="fixed top-0 left-0 w-full bg-orange-500 py-3 shadow-md z-50">
+  <div class="container mx-auto flex items-center px-4 relative">
+    
+    <!-- タイトル中央 -->
+    <h1 class="text-white text-lg font-semibold absolute left-1/2 transform -translate-x-1/2">
+      <%= link_to "Walking Monster", root_path, class: "hover:opacity-80" %>
+    </h1>
+
+    <!-- 右端 ユーザーメニュー（ハンバーガー） -->
+    <div class="ml-auto relative">
+      <button id="userMenuButton" class="p-2 w-10 h-10 rounded-full bg-white hover:bg-orange-300 transition shadow-md flex items-center justify-center">
+        <svg class="w-6 h-6 text-orange-500" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M12 12c2.7 0 4.8-2.1 4.8-4.8S14.7 2.4 12 2.4 7.2 4.5 7.2 7.2 9.3 12 12 12zm0 2.4c-3.2 0-9.6 1.6-9.6 4.8v1.2h19.2v-1.2c0-3.2-6.4-4.8-9.6-4.8z"/>
+        </svg>
+      </button>
+
+      <!-- ドロップダウンメニュー -->
+      <div id="userMenu" class="hidden absolute right-0 mt-2 w-60 bg-white rounded-xl shadow-xl ring-1 ring-gray-200 z-50 transition transform origin-top animate-fade-in-down">
+        <%= link_to "プロフィール", user_profile_path, class: "block px-5 py-3 text-gray-700 hover:bg-gray-100 font-medium" %>
+        <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { turbo_method: :delete }, class: "block px-5 py-3 text-gray-700 hover:bg-gray-100 font-medium" %>
+        <%= link_to "お問い合わせ", contact_path, class: "block px-5 py-3 text-gray-700 hover:bg-gray-100 font-medium" %>
+        <%= link_to "利用規約", terms_path, class: "block px-5 py-3 text-gray-700 hover:bg-gray-100 font-medium" %>
+        <%= link_to "プライバシーポリシー", privacy_path, class: "block px-5 py-3 text-gray-700 hover:bg-gray-100 font-medium" %>
+      </div>
+    </div>
+  </div>
+</header>
+
+<script>
+  document.addEventListener("turbo:load", () => {
+    const button = document.getElementById("userMenuButton");
+    const menu = document.getElementById("userMenu");
+
+    if (!button || !menu) return;
+
+    // ボタンクリックで開閉
+    button.addEventListener("click", (e) => {
+      e.stopPropagation();
+      menu.classList.toggle("hidden");
+    });
+
+    // メニュー外クリックで閉じる
+    document.addEventListener("click", (e) => {
+      if (!menu.contains(e.target) && !button.contains(e.target)) {
+        menu.classList.add("hidden");
+      }
+    });
+  });
+</script>


### PR DESCRIPTION
実装内容

・PC/スマホ版ヘッダーを追加

・PC/スマホ版フッターを追加

・PC/スマホ版ヘッダー分岐を追加

・PC/スマホ版フッター分岐を追加

・PC版フッターのみサイドメニューを追加

・スマホ版のフッターのみナビゲーション機能に変更

・ログイン後のPC版ヘッダーの右端ハンバーガーメニューをユーザーアイコンに変更